### PR TITLE
Support excluding certain directories from quota

### DIFF
--- a/get-quota-your-home/generate.py
+++ b/get-quota-your-home/generate.py
@@ -107,6 +107,7 @@ def reconcile_projfiles(paths, projects_file_path, projid_file_path, min_projid,
             if ent.name not in exclude_dirs and  ent.is_dir():
                 homedirs.append(ent.path)
 
+    homedirs.sort()
     print(homedirs)
 
     # Fetch list of projects in /etc/projid file, assumed to sync'd to /etc/projects file

--- a/get-quota-your-home/tests.py
+++ b/get-quota-your-home/tests.py
@@ -25,7 +25,7 @@ def test_reconcile_projids():
             for s in homedirs:
                 os.mkdir(os.path.join(base_dir, s))
 
-            reconcile_projfiles([base_dir], projects_file.name, projid_file.name, 1000)
+            reconcile_projfiles([base_dir], projects_file.name, projid_file.name, 1000, [])
 
             projects_file.flush()
             projid_file.flush()

--- a/get-quota-your-home/tests.py
+++ b/get-quota-your-home/tests.py
@@ -3,15 +3,16 @@ import tempfile
 from generate import reconcile_projfiles, OWNERSHIP_PREAMBLE
 import subprocess
 
+
 def test_reconcile_projids():
     # Given this set of home directories, after each run, the projid file should have exactly these dirs with these ids
     homedirs_sequence = [
         # base set of home directories
-        {'a': 1001, 'b': 1002, 'c': 1003},
+        {"a": 1001, "b": 1002, "c": 1003},
         # We remove 'c', but add 'd'. This should remove 'c' from projfiles, add 'd' with new id
-        {'a': 1001, 'b': 1002, 'd': 1004},
+        {"a": 1001, "b": 1002, "d": 1004},
         # We re-add 'c', which should give it a new id
-        {'a': 1001, 'b': 1002, 'd': 1004, 'c': 1005},
+        {"a": 1001, "b": 1002, "d": 1004, "c": 1005},
     ]
 
     with tempfile.NamedTemporaryFile() as projects_file, tempfile.NamedTemporaryFile() as projid_file, tempfile.TemporaryDirectory() as base_dir:
@@ -25,7 +26,9 @@ def test_reconcile_projids():
             for s in homedirs:
                 os.mkdir(os.path.join(base_dir, s))
 
-            reconcile_projfiles([base_dir], projects_file.name, projid_file.name, 1000, [])
+            reconcile_projfiles(
+                [base_dir], projects_file.name, projid_file.name, 1000, []
+            )
 
             projects_file.flush()
             projid_file.flush()
@@ -35,8 +38,103 @@ def test_reconcile_projids():
             projid_contents = projid_file.read().decode()
             projects_contents = projects_file.read().decode()
 
-            expected_projid_contents = OWNERSHIP_PREAMBLE + '\n'.join([f'{os.path.join(base_dir, k)}:{v}' for k, v in homedirs.items()]) + '\n'
-            expected_projects_contents = OWNERSHIP_PREAMBLE + '\n'.join([f'{v}:{os.path.join(base_dir, k)}' for k, v in homedirs.items()]) + '\n'
+            expected_projid_contents = (
+                OWNERSHIP_PREAMBLE
+                + "\n".join(
+                    [f"{os.path.join(base_dir, k)}:{v}" for k, v in homedirs.items()]
+                )
+                + "\n"
+            )
+            expected_projects_contents = (
+                OWNERSHIP_PREAMBLE
+                + "\n".join(
+                    [f"{v}:{os.path.join(base_dir, k)}" for k, v in homedirs.items()]
+                )
+                + "\n"
+            )
 
             assert projid_contents == expected_projid_contents
             assert projects_contents == expected_projects_contents
+
+
+def test_exclude_dirs():
+    """
+    Test that we can exclude dirs from quota reconciliation
+    """
+    homedirs = {"a": 1001, "b": 1002, "c": 1003}
+    exclude_dirs = ["a"]
+    with tempfile.NamedTemporaryFile() as projects_file, tempfile.NamedTemporaryFile() as projid_file, tempfile.TemporaryDirectory() as base_dir:
+        for d in os.listdir(base_dir):
+            # using rmdir so we don't accidentally rm -rf things
+            os.rmdir(os.path.join(base_dir, d))
+
+        for s in homedirs:
+            os.mkdir(os.path.join(base_dir, s))
+
+        # First reconcile without any exclusions
+        reconcile_projfiles([base_dir], projects_file.name, projid_file.name, 1000, [])
+        # make sure we have all the homedirs
+        projects_file.flush()
+        projid_file.flush()
+        projid_file.seek(0)
+        projects_file.seek(0)
+
+        projid_contents = projid_file.read().decode()
+        projects_contents = projects_file.read().decode()
+
+        expected_projid_contents = (
+            OWNERSHIP_PREAMBLE
+            + "\n".join(
+                [f"{os.path.join(base_dir, k)}:{v}" for k, v in homedirs.items()]
+            )
+            + "\n"
+        )
+        expected_projects_contents = (
+            OWNERSHIP_PREAMBLE
+            + "\n".join(
+                [f"{v}:{os.path.join(base_dir, k)}" for k, v in homedirs.items()]
+            )
+            + "\n"
+        )
+
+        assert projid_contents == expected_projid_contents
+        assert projects_contents == expected_projects_contents
+
+        # Now reconcile with exclusions
+        reconcile_projfiles(
+            [base_dir], projects_file.name, projid_file.name, 1000, exclude_dirs
+        )
+
+        projects_file.flush()
+        projid_file.flush()
+        projid_file.seek(0)
+        projects_file.seek(0)
+
+        projid_contents = projid_file.read().decode()
+        projects_contents = projects_file.read().decode()
+
+        expected_homedirs = {k: v for k, v in homedirs.items() if k not in exclude_dirs}
+
+        expected_projid_contents = (
+            OWNERSHIP_PREAMBLE
+            + "\n".join(
+                [
+                    f"{os.path.join(base_dir, k)}:{v}"
+                    for k, v in expected_homedirs.items()
+                ]
+            )
+            + "\n"
+        )
+        expected_projects_contents = (
+            OWNERSHIP_PREAMBLE
+            + "\n".join(
+                [
+                    f"{v}:{os.path.join(base_dir, k)}"
+                    for k, v in expected_homedirs.items()
+                ]
+            )
+            + "\n"
+        )
+
+        assert projid_contents == expected_projid_contents
+        assert projects_contents == expected_projects_contents

--- a/helm/jupyterhub-home-nfs/Chart.yaml
+++ b/helm/jupyterhub-home-nfs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: jupyterhub-home-nfs
 description: A Helm chart for an in-cluster NFS server with storage quota enforcement
-version: 0.0.7
-appVersion: "0.0.7"
+version: 0.0.8
+appVersion: "0.0.8"

--- a/helm/jupyterhub-home-nfs/Chart.yaml
+++ b/helm/jupyterhub-home-nfs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: jupyterhub-home-nfs
 description: A Helm chart for an in-cluster NFS server with storage quota enforcement
-version: 0.0.8
-appVersion: "0.0.8"
+version: 0.0.9
+appVersion: "0.0.9"

--- a/helm/jupyterhub-home-nfs/templates/deployment.yaml
+++ b/helm/jupyterhub-home-nfs/templates/deployment.yaml
@@ -7,6 +7,11 @@ spec:
   selector:
     matchLabels:
       app: nfs-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/helm/jupyterhub-home-nfs/templates/deployment.yaml
+++ b/helm/jupyterhub-home-nfs/templates/deployment.yaml
@@ -36,13 +36,7 @@ spec:
         volumeMounts:
         - name: home-directories
           mountPath: /export
-        resources:
-          requests:
-            cpu: {{ .Values.nfsServer.cpu.request | default null }}
-            memory: {{ .Values.nfsServer.memory.request | default null }}
-          limits:
-            cpu: {{ .Values.nfsServer.cpu.limit | default null }}
-            memory: {{ .Values.nfsServer.memory.limit | default null }}
+        resources: {{ toJson .Values.nfsServer.resources }}
       - name: enforce-xfs-quota
         image: "{{ .Values.quotaEnforcer.image.repository }}:{{ .Values.quotaEnforcer.image.tag }}"
         command: ["/usr/local/bin/generate.py", "{{ .Values.quotaEnforcer.path }}", "--hard-quota", "{{ .Values.quotaEnforcer.hardQuota }}"]
@@ -52,12 +46,7 @@ spec:
         - name: home-directories
           mountPath: /export
         resources:
-          requests:
-            cpu: {{ .Values.quotaEnforcer.cpu.request | default null }}
-            memory: {{ .Values.quotaEnforcer.memory.request | default null }}
-          limits:
-            cpu: {{ .Values.quotaEnforcer.cpu.limit | default null }}
-            memory: {{ .Values.quotaEnforcer.memory.limit | default null }}
+          requests: {{ toJson .Values.quotaEnforcer.resources }}
       {{- if .Values.prometheusExporter.enabled }}
       - name: metrics-exporter
         image: "{{ .Values.prometheusExporter.image.repository }}:{{ .Values.prometheusExporter.image.tag }}"
@@ -75,13 +64,7 @@ spec:
           # Mounting under /shared-volume to match path in dashboard definition in jupyterhub/grafana-dashboards
           mountPath: /shared-volume
           readOnly: true
-        resources:
-          requests:
-            cpu: {{ .Values.prometheusExporter.cpu.request | default null }}
-            memory: {{ .Values.prometheusExporter.memory.request | default null }}
-          limits:
-            cpu: {{ .Values.prometheusExporter.cpu.limit | default null }}
-            memory: {{ .Values.prometheusExporter.memory.limit | default null }}
+        resources: {{ toJson .Values.prometheusExporter.resources }}
       {{- end }}
       volumes:
       - name: home-directories

--- a/helm/jupyterhub-home-nfs/templates/deployment.yaml
+++ b/helm/jupyterhub-home-nfs/templates/deployment.yaml
@@ -36,6 +36,13 @@ spec:
         volumeMounts:
         - name: home-directories
           mountPath: /export
+        resources:
+          requests:
+            cpu: {{ .Values.nfsServer.cpu.request | default null }}
+            memory: {{ .Values.nfsServer.memory.request | default null }}
+          limits:
+            cpu: {{ .Values.nfsServer.cpu.limit | default null }}
+            memory: {{ .Values.nfsServer.memory.limit | default null }}
       - name: enforce-xfs-quota
         image: "{{ .Values.quotaEnforcer.image.repository }}:{{ .Values.quotaEnforcer.image.tag }}"
         command: ["/usr/local/bin/generate.py", "{{ .Values.quotaEnforcer.path }}", "--hard-quota", "{{ .Values.quotaEnforcer.hardQuota }}"]
@@ -44,6 +51,13 @@ spec:
         volumeMounts:
         - name: home-directories
           mountPath: /export
+        resources:
+          requests:
+            cpu: {{ .Values.quotaEnforcer.cpu.request | default null }}
+            memory: {{ .Values.quotaEnforcer.memory.request | default null }}
+          limits:
+            cpu: {{ .Values.quotaEnforcer.cpu.limit | default null }}
+            memory: {{ .Values.quotaEnforcer.memory.limit | default null }}
       {{- if .Values.prometheusExporter.enabled }}
       - name: metrics-exporter
         image: "{{ .Values.prometheusExporter.image.repository }}:{{ .Values.prometheusExporter.image.tag }}"
@@ -61,6 +75,13 @@ spec:
           # Mounting under /shared-volume to match path in dashboard definition in jupyterhub/grafana-dashboards
           mountPath: /shared-volume
           readOnly: true
+        resources:
+          requests:
+            cpu: {{ .Values.prometheusExporter.cpu.request | default null }}
+            memory: {{ .Values.prometheusExporter.memory.request | default null }}
+          limits:
+            cpu: {{ .Values.prometheusExporter.cpu.limit | default null }}
+            memory: {{ .Values.prometheusExporter.memory.limit | default null }}
       {{- end }}
       volumes:
       - name: home-directories

--- a/helm/jupyterhub-home-nfs/templates/deployment.yaml
+++ b/helm/jupyterhub-home-nfs/templates/deployment.yaml
@@ -45,8 +45,7 @@ spec:
         volumeMounts:
         - name: home-directories
           mountPath: /export
-        resources:
-          requests: {{ toJson .Values.quotaEnforcer.resources }}
+        resources: {{ toJson .Values.quotaEnforcer.resources }}
       {{- if .Values.prometheusExporter.enabled }}
       - name: metrics-exporter
         image: "{{ .Values.prometheusExporter.image.repository }}:{{ .Values.prometheusExporter.image.tag }}"

--- a/helm/jupyterhub-home-nfs/values.yaml
+++ b/helm/jupyterhub-home-nfs/values.yaml
@@ -5,6 +5,12 @@ nfsServer:
   image:
     repository: ghcr.io/2i2c-org/nfs-ganesha
     tag: 0.0.7
+  cpu:
+    request:
+    limit:
+  memory:
+    request:
+    limit:
 
 # Quota enforcer configuration
 # This container enforces the quota on the home directories
@@ -16,6 +22,12 @@ quotaEnforcer:
   path: "/export"
   # quota in GB
   hardQuota: "10"
+  cpu:
+    request:
+    limit:
+  memory:
+    request:
+    limit:
 
 # Prometheus exporter configuration
 # We export disk usage metrics using the Prometheus node exporter
@@ -25,6 +37,12 @@ prometheusExporter:
   image:
     repository: quay.io/prometheus/node-exporter
     tag: v1.8.2
+  cpu:
+    request:
+    limit:
+  memory:
+    request:
+    limit:
 
 # Persistent volume configuration
 

--- a/helm/jupyterhub-home-nfs/values.yaml
+++ b/helm/jupyterhub-home-nfs/values.yaml
@@ -5,12 +5,7 @@ nfsServer:
   image:
     repository: ghcr.io/2i2c-org/nfs-ganesha
     tag: 0.0.7
-  cpu:
-    request:
-    limit:
-  memory:
-    request:
-    limit:
+  resources: {}
 
 # Quota enforcer configuration
 # This container enforces the quota on the home directories
@@ -22,12 +17,7 @@ quotaEnforcer:
   path: "/export"
   # quota in GB
   hardQuota: "10"
-  cpu:
-    request:
-    limit:
-  memory:
-    request:
-    limit:
+  resources: {}
 
 # Prometheus exporter configuration
 # We export disk usage metrics using the Prometheus node exporter
@@ -37,12 +27,7 @@ prometheusExporter:
   image:
     repository: quay.io/prometheus/node-exporter
     tag: v1.8.2
-  cpu:
-    request:
-    limit:
-  memory:
-    request:
-    limit:
+  resources: {}
 
 # Persistent volume configuration
 


### PR DESCRIPTION
We have _shared and _shared-public directories that should have a different quota setup. While we wait for implementation of a tiered quota config system, this simply allows us to exclude them from being quota'd