### PR TITLE
Test against some more modern versions of python

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.8 is end of life, so we should test against more modern versions.

I picked some off the top of my head, they're not particularly bleeding edge, so we can go higher if desired. https://devguide.python.org/versions/