### PR TITLE
Edit RollingUpdate strategy for nfs-deployment

### DIFF
--- a/helm/jupyterhub-home-nfs/Chart.yaml
+++ b/helm/jupyterhub-home-nfs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: jupyterhub-home-nfs
 description: A Helm chart for an in-cluster NFS server with storage quota enforcement
-version: 0.0.8
-appVersion: "0.0.8"
+version: 0.0.9
+appVersion: "0.0.9"

--- a/helm/jupyterhub-home-nfs/templates/deployment.yaml
+++ b/helm/jupyterhub-home-nfs/templates/deployment.yaml
@@ -7,6 +7,11 @@ spec:
   selector:
     matchLabels:
       app: nfs-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
When making some changes, I ended up stuck mid-deployment with a Multi-Attach error on the PV/PVC. Because the volume has ReadWriteOnce access mode, it cannot be attached to more than resource simultaneously, and the update strategy was trying to bring up a new pod before taking down the old. Causing the Multi-Attach error and stalemate.

By setting `maxSurge` and `maxUnavailable` to one (instead of the default 25%), we permit one more replica than defined, and one replica is permitted to be unavailable during upgrade. This permits the terminating pod to release the volume for the  creating pod to bind to.

See https://github.com/2i2c-org/infrastructure/pull/5487 for details.