### PR TITLE
change how version is parsed, move from `set-output` to use `$GITHUB_ENV`, skip publish for certain commits

### DIFF
--- a/.github/workflows/build-publish-docker-helm.yaml
+++ b/.github/workflows/build-publish-docker-helm.yaml
@@ -5,6 +5,14 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "LICENSE"
+      - "README.md"
+      - "RELEASE.md"
+      - ".pre-commit-config.yaml"
+      - ".github/**"
+      - ".gitignore"
+
     tags:
       - "**"
 

--- a/.github/workflows/build-publish-docker-helm.yaml
+++ b/.github/workflows/build-publish-docker-helm.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat helm/jupyterhub-home-nfs/Chart.yaml | grep version | awk '{print $2}')
+        run: echo "VERSION=$(grep "version:" helm/jupyterhub-home-nfs/Chart.yaml | awk '{print $2}')" >> $GITHUB_ENV
 
       - name: Package Helm Chart
         run: |
@@ -56,4 +56,4 @@ jobs:
 
       - name: Push Helm Chart
         run: |
-          helm push .helm-charts/jupyterhub-home-nfs-${{ steps.get_version.outputs.VERSION }}.tgz oci://ghcr.io/2i2c-org/jupyterhub-home-nfs
+          helm push .helm-charts/jupyterhub-home-nfs-${{ env.VERSION }}.tgz oci://ghcr.io/2i2c-org/jupyterhub-home-nfs

--- a/.github/workflows/build-publish-docker-helm.yaml
+++ b/.github/workflows/build-publish-docker-helm.yaml
@@ -12,7 +12,6 @@ on:
       - ".pre-commit-config.yaml"
       - ".github/**"
       - ".gitignore"
-
     tags:
       - "**"
 

--- a/.github/workflows/build-publish-docker-helm.yaml
+++ b/.github/workflows/build-publish-docker-helm.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo "VERSION=$(grep "version:" helm/jupyterhub-home-nfs/Chart.yaml | awk '{print $2}')" >> $GITHUB_ENV
+        run: echo "VERSION=$(grep "^version:" helm/jupyterhub-home-nfs/Chart.yaml | awk '{print $2}')" >> $GITHUB_ENV
 
       - name: Package Helm Chart
         run: |


### PR DESCRIPTION
minor PR here, as i noticed this stuff whilst perusing the repo...

1. there's really no need to `cat` the chart config, just `grep` it directly
2. added a `^` to the regex in grep to ensure that only the proper line is matched
3. `set-output` is deprecated, and using `echo "whatever=whatevervalue" >> $GITHUB_ENV` is the preferred way to store values like this
4. added `ignore-files` so that the publish/push workflow is skipped for minor changes to docs, workflows etc
