### PR TITLE
Add standard Helm labels to Kubernetes resources

### DIFF
--- a/helm/jupyterhub-home-nfs/templates/_helpers.tpl
+++ b/helm/jupyterhub-home-nfs/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "jupyterhub-home-nfs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "jupyterhub-home-nfs.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "jupyterhub-home-nfs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "jupyterhub-home-nfs.labels" -}}
+helm.sh/chart: {{ include "jupyterhub-home-nfs.chart" . }}
+{{ include "jupyterhub-home-nfs.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "jupyterhub-home-nfs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "jupyterhub-home-nfs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/jupyterhub-home-nfs/templates/deployment.yaml
+++ b/helm/jupyterhub-home-nfs/templates/deployment.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-nfs-deployment
+  labels:
+    {{- include "jupyterhub-home-nfs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nfs-server
 spec:
   replicas: 1
   selector:
@@ -15,6 +18,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "jupyterhub-home-nfs.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: nfs-server
         app: nfs-server
         # The component label is used by the shared volume free space panel
         # in jupyterhub/grafana-dashboards

--- a/helm/jupyterhub-home-nfs/templates/persistent-volume-claim.yaml
+++ b/helm/jupyterhub-home-nfs/templates/persistent-volume-claim.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-nfs-home-directories-claim
+  labels:
+    {{- include "jupyterhub-home-nfs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: storage
 spec:
   accessModes:
     {{- toYaml .Values.persistentVolume.accessModes | nindent 4 }}

--- a/helm/jupyterhub-home-nfs/templates/persistent-volume.yaml
+++ b/helm/jupyterhub-home-nfs/templates/persistent-volume.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ .Release.Name }}-nfs-home-directories-volume
+  {{- if .Values.persistentVolume.addStandardLabels }}
+  labels:
+    {{- include "jupyterhub-home-nfs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: storage
+  {{- end }}
 spec:
   capacity:
     storage: {{ .Values.persistentVolume.size }}

--- a/helm/jupyterhub-home-nfs/templates/secret.yaml
+++ b/helm/jupyterhub-home-nfs/templates/secret.yaml
@@ -6,6 +6,8 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-secret
+  labels:
+    {{- include "jupyterhub-home-nfs.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   {{- /*

--- a/helm/jupyterhub-home-nfs/templates/service.yaml
+++ b/helm/jupyterhub-home-nfs/templates/service.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-nfs-service
+  labels:
+    {{- include "jupyterhub-home-nfs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nfs-server
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/jupyterhub-home-nfs/values.yaml
+++ b/helm/jupyterhub-home-nfs/values.yaml
@@ -60,6 +60,11 @@ prometheusExporter:
 # Persistent volume configuration
 
 persistentVolume:
+  # WARNING: Adding labels to existing PersistentVolumes may fail during upgrades
+  # as PVs are largely immutable. Only enable this for new installations or if you
+  # understand the risks. PersistentVolumeClaims receive standard labels by default
+  # as they are more tolerant of updates.
+  addStandardLabels: false
   # Setting this to 1M to make it obvious that this is not the real size.
   # The value can be changed to the actual size of the pre-provisioned disk to correctly
   # label the PV and PVC with the underlying disk size.


### PR DESCRIPTION
Implements standard Helm chart labels as recommended in issue #28:
- app.kubernetes.io/name
- app.kubernetes.io/instance
- app.kubernetes.io/version
- app.kubernetes.io/managed-by
- helm.sh/chart
- app.kubernetes.io/component