### PR TITLE
Implement quota overrides for specific folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## [Unreleased]
 
-Future changes that are not yet released.
+### Enhancements
+
+- Added quota override functionality for specific folders. This allows setting custom quotas for individual folders, which is particularly useful for shared folders that may need different quota limits than regular user directories. The feature is configured via the `quota_overrides` option which maps folder names to custom quota values in GB.
+
+  ```yaml
+  quotaEnforcer:
+    config:
+      QuotaManager:
+        quota_overrides:
+          "_shared-public": 50 # Custom quota of 50 GB for the shared public folder
+  ```
 
 ## v0.2.0 - 2025-04-21
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,7 +39,6 @@ To update the version:
    ```
 
    This will:
-
    - Update `__version__` in `jupyterhub_home_nfs/__init__.py`
    - Update version and appVersion in `helm/jupyterhub-home-nfs/Chart.yaml`
    - Create a git commit
@@ -57,7 +56,6 @@ To update the version:
 4. **CI Automation**
 
    Once we create a tag, the GitHub Actions workflow ([`build-publish-docker-helm.yaml`](https://github.com/2i2c-org/jupyterhub-home-nfs/blob/main/.github/workflows/build-publish-docker-helm.yaml)) will automatically:
-
    - Build the Docker images
    - Push them to GitHub Container Registry (ghcr.io)
    - Update the Helm chart with the new image tags

--- a/helm/jupyterhub-home-nfs/values.schema.json
+++ b/helm/jupyterhub-home-nfs/values.schema.json
@@ -45,7 +45,7 @@
                 "exclude": {
                   "type": "array",
                   "items": { "type": "string" }
-},
+                },
                 "quota_overrides": {
                   "type": "object",
                   "additionalProperties": { "type": "number" }

--- a/helm/jupyterhub-home-nfs/values.schema.json
+++ b/helm/jupyterhub-home-nfs/values.schema.json
@@ -45,6 +45,10 @@
                 "exclude": {
                   "type": "array",
                   "items": { "type": "string" }
+},
+                "quota_overrides": {
+                  "type": "object",
+                  "additionalProperties": { "type": "number" }
                 }
               },
               "required": ["paths", "hard_quota", "wait_time", "min_projid"]

--- a/helm/jupyterhub-home-nfs/values.yaml
+++ b/helm/jupyterhub-home-nfs/values.yaml
@@ -32,6 +32,7 @@ quotaEnforcer:
       wait_time: 30
       min_projid: 1000
       exclude: []
+      quota_overrides: {}
 
   # The keys and values below are rendered by a k8s Secret and mounted as a .py
   # file together with quota-enforcer-config.py. These are then executed by the

--- a/jupyterhub_home_nfs/generate.py
+++ b/jupyterhub_home_nfs/generate.py
@@ -34,7 +34,7 @@ import subprocess
 import sys
 import time
 
-from traitlets import Float, Int, List, Unicode
+from traitlets import Dict, Float, Int, List, Unicode
 from traitlets.config import Application
 
 # Line at beginning of projid / projects file stating ownership
@@ -150,7 +150,7 @@ def reconcile_projfiles(paths, projects_file_path, projid_file_path, min_projid)
         )
 
 
-def reconcile_quotas(projid_file_path, hard_quota_kb, exclude_dirs):
+def reconcile_quotas(projid_file_path, hard_quota_kb, exclude_dirs, quota_overrides_kb):
     """
     Make sure each project in /etc/projid has correct hard quota set
     """
@@ -169,12 +169,19 @@ def reconcile_quotas(projid_file_path, hard_quota_kb, exclude_dirs):
         )
         print(f"Setting up xfs_quota project for {project}")
 
-    # If exclude_dirs is provided, set quotas to 0 for those projects,
-    # otherwise set the intended quota to hard_quota_kb
-    intended_quotas = {
-        project: (hard_quota_kb if os.path.basename(project) not in exclude_dirs else 0)
-        for project in projects
-    }
+    # Set quotas based on priority: quota_overrides > exclude_dirs > hard_quota_kb
+    intended_quotas = {}
+    for project in projects:
+        dirname = os.path.basename(project)
+        if dirname in quota_overrides_kb:
+            # Override takes highest priority
+            intended_quotas[project] = quota_overrides_kb[dirname]
+        elif dirname in exclude_dirs:
+            # Exclude means 0 quota
+            intended_quotas[project] = 0
+        else:
+            # Default quota
+            intended_quotas[project] = hard_quota_kb
 
     print(f"Intended quotas: {intended_quotas}")
 
@@ -242,6 +249,12 @@ class QuotaManager(Application):
         help="List of directory names to exclude setting quotas on",
     ).tag(config=True)
 
+    quota_overrides = Dict(
+        value_trait=Float(),
+        default_value={},
+        help="Dictionary mapping directory names to custom quota limits (in GB)",
+    ).tag(config=True)
+
     aliases = {
         "config-file": "QuotaManager.config_file",
         "paths": "QuotaManager.paths",
@@ -251,6 +264,7 @@ class QuotaManager(Application):
         "wait-time": "QuotaManager.wait_time",
         "hard-quota": "QuotaManager.hard_quota",
         "exclude": "QuotaManager.exclude",
+        "quota-overrides": "QuotaManager.quota_overrides",
     }
 
     def initialize(self, argv=None):
@@ -273,8 +287,16 @@ class QuotaManager(Application):
     def _reconcile_quotas(self):
         # Convert GB to KB for xfs_quota
         hard_quota_kb = int(self.hard_quota * 1024 * 1024)
+        # Convert quota_overrides from GB to KB
+        quota_overrides_kb = {
+            dirname: int(quota_gb * 1024 * 1024)
+            for dirname, quota_gb in self.quota_overrides.items()
+        }
         reconcile_quotas(
-            self.projid_file, hard_quota_kb=hard_quota_kb, exclude_dirs=self.exclude
+            self.projid_file, 
+            hard_quota_kb=hard_quota_kb, 
+            exclude_dirs=self.exclude,
+            quota_overrides_kb=quota_overrides_kb
         )
 
     def start(self):

--- a/jupyterhub_home_nfs/generate.py
+++ b/jupyterhub_home_nfs/generate.py
@@ -293,10 +293,10 @@ class QuotaManager(Application):
             for dirname, quota_gb in self.quota_overrides.items()
         }
         reconcile_quotas(
-            self.projid_file, 
-            hard_quota_kb=hard_quota_kb, 
+            self.projid_file,
+            hard_quota_kb=hard_quota_kb,
             exclude_dirs=self.exclude,
-            quota_overrides_kb=quota_overrides_kb
+            quota_overrides_kb=quota_overrides_kb,
         )
 
     def start(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -51,7 +51,7 @@ def _reset_quotas(base_dir, projects_file, projid_file, homedirs):
 
     # reconcile the projects and projid files
     reconcile_projfiles([MOUNT_POINT], projects_file.name, projid_file.name, 1000)
-    reconcile_quotas(projid_file.name, 1000, [])
+    reconcile_quotas(projid_file.name, 1000, [], {})
 
 
 def test_reconcile_projids():
@@ -152,7 +152,7 @@ def test_exclude_dirs():
 
         # Now reconcile with exclusions
         reconcile_projfiles([base_dir], projects_file.name, projid_file.name, 1000)
-        reconcile_quotas(projid_file.name, 1000, exclude_dirs)
+        reconcile_quotas(projid_file.name, 1000, exclude_dirs, {})
 
         # Now test the output of "xfs_quota -x -c 'report -N -p'"
         # We should see the same number of projects as there are homedirs
@@ -270,3 +270,159 @@ def test_config_file():
                 subprocess.check_output(
                     ["cp", test_file.name, os.path.join(MOUNT_POINT, "d", "2MB.bin")]
                 )
+
+
+def test_quota_overrides():
+    """Test that quota overrides work correctly with different priority levels"""
+    homedirs = {"regular": 1001, "excluded": 1002, "override": 1003, "both": 1004}
+    
+    projects_file_path = "/etc/projects"
+    projid_file_path = "/etc/projid"
+    base_dir = MOUNT_POINT
+    
+    with (
+        open(projects_file_path, "w+b") as projects_file,
+        open(projid_file_path, "w+b") as projid_file,
+    ):
+        _reset_quotas(base_dir, projects_file, projid_file, list(homedirs.keys()))
+        
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py") as config_file:
+            # Write test config with quota overrides
+            config_content = textwrap.dedent(
+                f"""
+                c.QuotaManager.projects_file = "{projects_file.name}"
+                c.QuotaManager.projid_file = "{projid_file.name}"
+                c.QuotaManager.paths = ["{base_dir}"]
+                c.QuotaManager.hard_quota = 0.001  # 1MB default
+                c.QuotaManager.exclude = ["excluded", "both"]  # both is in exclude AND override
+                c.QuotaManager.quota_overrides = {{
+                    "override": 0.005,  # 5MB custom quota
+                    "both": 0.003       # 3MB custom quota (should override exclude)
+                }}
+                """
+            )
+            
+            config_file.write(config_content)
+            config_file.flush()
+            
+            # Create QuotaManager instance with our config
+            manager = QuotaManager()
+            manager.initialize(["--config-file", config_file.name])
+            
+            # Verify config values were loaded correctly
+            assert manager.hard_quota == 0.001
+            assert manager.exclude == ["excluded", "both"]
+            assert manager.quota_overrides == {"override": 0.005, "both": 0.003}
+            
+            # Apply the quotas
+            manager._reconcile_projfiles()
+            manager._reconcile_quotas()
+            
+            # Check quota output to verify settings
+            quota_output = subprocess.check_output(
+                ["xfs_quota", "-x", "-c", "report -N -p"]
+            ).decode()
+            quota_output_lines = [line for line in quota_output.split("\n") if line.strip()]
+            
+            # Helper function to get quota for a directory
+            def get_quota_for_dir(dirname):
+                line = next(
+                    line for line in quota_output_lines 
+                    if line.startswith(f"{MOUNT_POINT}/{dirname}")
+                )
+                return int(line.split()[3])  # hard quota is 4th column
+            
+            # Test quota priorities:
+            # 1. "regular": should get default hard_quota (1MB = 1024KB)
+            assert get_quota_for_dir("regular") == 1024
+            
+            # 2. "excluded": should get 0 quota (excluded)
+            assert get_quota_for_dir("excluded") == 0
+            
+            # 3. "override": should get custom quota (5MB = 5120KB)
+            assert get_quota_for_dir("override") == 5120
+            
+            # 4. "both": should get override quota, NOT excluded (3MB = 3072KB)
+            # This tests that quota_overrides takes priority over exclude
+            assert get_quota_for_dir("both") == 3072
+            
+            # Test actual file operations to verify quotas work
+            with tempfile.NamedTemporaryFile() as small_file, tempfile.NamedTemporaryFile() as large_file:
+                # Create a 2MB test file
+                small_file.write(b"0" * 2 * 1024 * 1024)
+                small_file.flush()
+                
+                # Create a 4MB test file  
+                large_file.write(b"0" * 4 * 1024 * 1024)
+                large_file.flush()
+                
+                # Test "regular" directory (1MB quota) - should fail with 2MB file
+                with pytest.raises(subprocess.CalledProcessError):
+                    subprocess.check_output([
+                        "cp", small_file.name, os.path.join(MOUNT_POINT, "regular", "test.bin")
+                    ])
+                
+                # Test "excluded" directory (0 quota = unlimited) - should succeed with 2MB file
+                subprocess.check_output([
+                    "cp", small_file.name, os.path.join(MOUNT_POINT, "excluded", "test.bin")
+                ])
+                
+                # Test "override" directory (5MB quota) - should succeed with 4MB file
+                subprocess.check_output([
+                    "cp", large_file.name, os.path.join(MOUNT_POINT, "override", "test.bin")
+                ])
+                
+                # Test "both" directory (3MB quota due to override) - should succeed with 2MB but fail with 4MB
+                subprocess.check_output([
+                    "cp", small_file.name, os.path.join(MOUNT_POINT, "both", "test2mb.bin")
+                ])
+                
+                with pytest.raises(subprocess.CalledProcessError):
+                    subprocess.check_output([
+                        "cp", large_file.name, os.path.join(MOUNT_POINT, "both", "test4mb.bin")
+                    ])
+
+
+def test_quota_overrides_cli():
+    """Test that quota overrides can be set via CLI"""
+    homedirs = {"test": 1001}
+    
+    projects_file_path = "/etc/projects"
+    projid_file_path = "/etc/projid"
+    base_dir = MOUNT_POINT
+    
+    with (
+        open(projects_file_path, "w+b") as projects_file,
+        open(projid_file_path, "w+b") as projid_file,
+    ):
+        _reset_quotas(base_dir, projects_file, projid_file, list(homedirs.keys()))
+        
+        # Test CLI override (traitlets supports dict parsing from CLI)
+        manager = QuotaManager()
+        manager.initialize([
+            "--paths", base_dir,
+            "--projects-file", projects_file.name,
+            "--projid-file", projid_file.name,
+            "--hard-quota", "0.001",
+            "--quota-overrides", "{'test': 0.002}"
+        ])
+        
+        # Verify config values
+        assert manager.hard_quota == 0.001
+        assert manager.quota_overrides == {"test": 0.002}
+        
+        # Apply the quotas
+        manager._reconcile_projfiles()
+        manager._reconcile_quotas()
+        
+        # Check that the override was applied (2MB = 2048KB)
+        quota_output = subprocess.check_output(
+            ["xfs_quota", "-x", "-c", "report -N -p"]
+        ).decode()
+        quota_output_lines = [line for line in quota_output.split("\n") if line.strip()]
+        
+        test_line = next(
+            line for line in quota_output_lines 
+            if line.startswith(f"{MOUNT_POINT}/test")
+        )
+        assert int(test_line.split()[3]) == 2048  # 2MB in KB


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/jupyterhub-home-nfs/issues/16.

Implements a quota override feature that allows setting custom quotas for specific folders -- useful for setting separate quotas for shared folders.

Currently, the quota system only supports two modes for folders:
- **Default quota**: All folders get the same `hard_quota` value (e.g., 10GB)
- **Excluded**: Folders in the `exclude` list get unlimited quota (0 quota)

This limitation means we can only exclude shared folders from quota enforcement but cannot set custom quotas for shared folders that need specific storage limits different from the default.

This PR adds a new `quota_overrides` configuration option that allows mapping folder names to custom quota values in GB. Configuration in **values.yaml** looks like this: 
```yaml
quotaEnforcer:
  config:
    QuotaManager:
      hard_quota: 10  # 10GB default for regular folders
      exclude: ["some-folder"]  # unlimited quota
      quota_overrides:
        "shared": 100  # 100GB custom quota
```

The quota assignment follows this priority order:
1. **quota_overrides** (highest priority): Custom quotas for specific folders
2. **exclude** (medium priority): Unlimited quota for excluded folders  
3. **hard_quota** (default priority): Default quota for all other folders

If a folder appears in both `exclude` and `quota_overrides`, the override value takes precedence.

