### PR TITLE
PV name must be unique

### DIFF
--- a/helm/jupyterhub-home-nfs/templates/persistent-volume-claim.yaml
+++ b/helm/jupyterhub-home-nfs/templates/persistent-volume-claim.yaml
@@ -14,5 +14,5 @@ spec:
       storage: {{ .Values.persistentVolume.size }}
   storageClassName: ""
   {{- if or .Values.eks.enabled .Values.gke.enabled .Values.openstack.enabled}}
-  volumeName: {{ include "jupyterhub-home-nfs.home-nfs.fullname" . }}
+  volumeName: {{ .Release.Name }}-{{ include "jupyterhub-home-nfs.home-nfs.fullname" . }}
   {{- end }}

--- a/helm/jupyterhub-home-nfs/templates/persistent-volume.yaml
+++ b/helm/jupyterhub-home-nfs/templates/persistent-volume.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ include "jupyterhub-home-nfs.home-nfs.fullname" . }}
+  name: {{ .Release.Name }}-{{ include "jupyterhub-home-nfs.home-nfs.fullname" . }}
   {{- if .Values.persistentVolume.addStandardLabels }}
   labels:
     {{- include "jupyterhub-home-nfs.labels" . | nindent 4 }}


### PR DESCRIPTION
While trying to upgrade some hubs in the same cluster, I realized that with the current naming scheme the PVs will have the same name and since they're not namespaced, this is causing issue. This adds the release name as a prefix to the name.