### PR TITLE
Set PYTHONUNBUFFERED=1 for enforce-xfs-quotas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,8 @@ COPY ./jupyterhub_home_nfs /opt/jupyterhub-home-nfs/jupyterhub_home_nfs
 
 RUN pip install -e .
 
+# Don't buffer output, so all error logs get flushed immediately
+# Without this, exceptions may get swallowed sometime
+ENV PYTHONUNBUFFERED=1
+
 CMD ["python", "-m", "jupyterhub_home_nfs.generate"]


### PR DESCRIPTION
Without this, exceptions that terminate the program may not get written to stderr because they are in the buffer. And we may lose some of those logs, making debugging confusing