### PR TITLE
Squash all users to one particular uid and gid

### DIFF
--- a/helm/jupyterhub-home-nfs/templates/configmap.yaml
+++ b/helm/jupyterhub-home-nfs/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
             Anonymous_uid = 1000;
             Anonymous_gid = 1000;
             Access_Type = RW;
-            Squash = No_Root_Squash;
+            Squash = All_Squash;
             SecType = "sys";
         }
 


### PR DESCRIPTION
Ref: https://github.com/2i2c-org/infrastructure/issues/5560

Without this, setting `Anonymous_uid` and `Anonymous_gid` has no effect.

Also, this kind of squashing is ultimately what we want I believe.

`All_squash` is _"Map all uids and gids to the anonymous user. Useful for NFS-exported public FTP directories, news spool directories, etc. The opposite option is no_all_squash, which is the default setting. "_

Because we set the uid and gid to 1000, then this is who the anonymous user, exactly what we want.