### PR TITLE
feat: increase filesystem reconciliation granularity

### DIFF
--- a/jupyterhub_home_nfs/generate.py
+++ b/jupyterhub_home_nfs/generate.py
@@ -263,7 +263,7 @@ class QuotaManager(Application):
                 line.split() for line in result.stdout.decode().strip().splitlines()
             )
         }
-        return 
+        return
 
     def get_applied_quotas(self):
         """

--- a/jupyterhub_home_nfs/generate.py
+++ b/jupyterhub_home_nfs/generate.py
@@ -346,7 +346,7 @@ class QuotaManager(Application):
                         "xfs_quota",
                         "-x",
                         "-c",
-                        f"limit -p bhard={intended_quotas[project]}k {project}",
+                        f"limit -p bhard={intended_quotas[project]}k bsoft=0 ihard=0 isoft=0 rtbsoft=0 rtbhard=0 {project}",
                         "-D",
                         f"{self.projects_file}",
                         "-P",

--- a/jupyterhub_home_nfs/generate.py
+++ b/jupyterhub_home_nfs/generate.py
@@ -362,40 +362,11 @@ class QuotaManager(Application):
                 )
                 continue
 
-    def clear_existing_quotas(self):
-        for path in self.paths:
-            mountpoint = self.mountpoint_for(path)
-            # Create a new project with ID 1, and clear it
-            try:
-                logged_check_call(
-                    [
-                        "xfs_quota",
-                        "-x",
-                        "-c",
-                        f"project -C -p {path} 1",
-                        "-D",
-                        "/dev/null",
-                        "-P",
-                        "/dev/null",
-                        mountpoint,
-                    ],
-                    self.log,
-                )
-            except subprocess.CalledProcessError as e:
-                self.log.error(
-                    f"Clearing quotas for path {path} failed! Continuing...",
-                    exc_info=e,
-                )
-                continue
-
     def reconcile_step(self, *, is_dirty=False):
         self.reconcile_projfiles()
         self.reconcile_quotas(is_dirty=is_dirty)
 
-    def start(self):
-        # Clear all inode quota information
-        self.clear_existing_quotas()
-        # Forcibly update inodes with proper quotas
+    def start(self):        # Forcibly update inodes with proper quotas
         self.reconcile_step(is_dirty=True)
         while True:
             time.sleep(self.wait_time)

--- a/jupyterhub_home_nfs/generate.py
+++ b/jupyterhub_home_nfs/generate.py
@@ -366,7 +366,7 @@ class QuotaManager(Application):
         self.reconcile_projfiles()
         self.reconcile_quotas(is_dirty=is_dirty)
 
-    def start(self):        # Forcibly update inodes with proper quotas
+    def start(self):  # Forcibly update inodes with proper quotas
         self.reconcile_step(is_dirty=True)
         while True:
             time.sleep(self.wait_time)

--- a/jupyterhub_home_nfs/generate.py
+++ b/jupyterhub_home_nfs/generate.py
@@ -31,10 +31,10 @@ there that aren't put in there by this script, they will be removed!
 """
 
 import contextlib
+import itertools
 import logging
 import os
 import os.path
-import itertools
 import subprocess
 import sys
 import tempfile

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,9 +1,9 @@
+import itertools
 import os
+import re
 import subprocess
 import tempfile
 import textwrap
-import re
-import itertools
 from pprint import pprint  # noqa: F401
 
 import pytest
@@ -33,9 +33,9 @@ def cleanup_traitlet_singleton():
 def cleanup_fs():
     """Make sure we are running in Docker and have write access to the mount point"""
     # Make sure we have write access to /mnt/docker-test-xfs
-    assert os.access(MOUNT_POINT, os.W_OK), (
-        f"This test must be run with write access to {MOUNT_POINT}"
-    )
+    assert os.access(
+        MOUNT_POINT, os.W_OK
+    ), f"This test must be run with write access to {MOUNT_POINT}"
     # Clean-up homes
     clear_home_directories(MOUNT_POINT)
     yield

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -135,7 +135,7 @@ def test_exclude_dirs(quota_manager):
 
     # Reconcile with basic home directories
     create_home_directories(MOUNT_POINT, {"a": 1001, "b": 1002, "c": 1003})
-    quota_manager.reconcile_step(is_dirty=True)
+    quota_manager.reconcile_step(quotas_is_dirty=True)
 
     quota_output = subprocess.check_output(
         [
@@ -295,7 +295,7 @@ def test_config_file_override(tmp_path):
     homedirs = {"a": 1001, "b": 1002, "c": 1003, "d": 1004}
     create_home_directories(MOUNT_POINT, homedirs)
 
-    manager.reconcile_step(is_dirty=True)
+    manager.reconcile_step(quotas_is_dirty=True)
 
     # check that quota is enforced
     with tempfile.NamedTemporaryFile() as test_file:
@@ -332,7 +332,7 @@ def test_quota_overrides(quota_manager):
     }
 
     # Apply the quotas
-    quota_manager.reconcile_step(is_dirty=True)
+    quota_manager.reconcile_step(quotas_is_dirty=True)
 
     # Check quota output to verify settings
     quota_output = subprocess.check_output(
@@ -467,7 +467,7 @@ def test_quota_overrides_cli(tmp_path):
     create_home_directories(MOUNT_POINT, homedirs)
 
     # Apply the quotas
-    quota_manager.reconcile_step(is_dirty=True)
+    quota_manager.reconcile_step(quotas_is_dirty=True)
 
     # Check that the override was applied (2MB = 2048KB)
     quota_output = subprocess.check_output(
@@ -501,10 +501,9 @@ def test_quota_clear(quota_manager):
 
     quota_manager.paths = [MOUNT_POINT]
     quota_manager.hard_quota = 1  # 1GB
-    quota_manager.exclude = []  # both is in exclude AND override
 
     # Apply the quotas
-    quota_manager.reconcile_step(is_dirty=True)
+    quota_manager.reconcile_step(quotas_is_dirty=True)
 
     def get_quotas():
         # Check that the override was applied (2MB = 2048KB)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,4 @@
-import itertools
 import os
-import re
 import subprocess
 import tempfile
 import textwrap


### PR DESCRIPTION
### Summary

This PR increases the granularity of state reconciliation dirty tracking between the intrinsic file-system attributes and the expected state of the system. The goal is to solve the problem of improper imposition of quotas and attribution of usage across unrelated projects.

Specifically, this PR solves the the problem of new folders being give previously-used project IDs that are already associated with quotas. 

Closes #47

### Context

2i2c noticed that certain users were ascribed usage from other users on NFS servers running jupyterhub-home-nfs. It became apparent that the underlying filesystem quota information was desyncing from the expected model of the system

#51 attempted to resolve an aspect of this problem by clearing the project IDs of existing directories on startup, and setting new values derived from the projid files. However, this PR did not go far enough — although it fixed improper attribution of usage, it was/is still possible to break the quota system. This can happen if e.g.:

1. Folders `a`, and `b` are created with intended quotas `quota(a)` and `quota(b)`, and intended ID mappings `a:1` and `b:2`.
2. The IDs and quotas are applied to the FS.
3. Folder `b` is deleted, and removed from the ID mapping.
4. Folder `c` is created, and given intended ID `2` and quota `quota(c)`.

At this point, `jupyterhub-home-nfs` doesn't actually update the file system. The reason is that we check whether `c` has a quota before resetting it. In this case, `c` _does_ have a quota — the quota from `b` (due to ID reuse)!

### Technical Context

XFS quota information is stored in several places:

1. The projects/projid files used by `xfs_quota` to provide human-readable paths for project IDs.
2. The projid attribute of individual inodes.
6. The top-level projid quota information stored on the mounted quota-enabled filesystem.

It can be read out in several ways:
(1) can be read by `cat`ing the individual files. It also affects the output of `xfs_quota -x -c report`.
(2) can be read by `lsattr -p <MOUNT>`.
(3) can be read by `xfs_quota -x -c report`.

It can be written to in several ways:
(1) can be written to by directly writing the projid/projects files.
(2) can be written to by `xfs_quota -x -c 'project -s ...'`
(3) can be written to by `xfs_quota -x -c 'limit ...'`

Common scenarios worth noticing:
- Deleting a folder removes its association with a project ID — recreating a folder with the same path will _not_ associate it with that project or quota.
- Setting a new folder with an old (unused) project ID will impose the original quotas (they're still on the file system)
