### PR TITLE
feat: pass through file paths

### DIFF
--- a/helm/jupyterhub-home-nfs/values.schema.json
+++ b/helm/jupyterhub-home-nfs/values.schema.json
@@ -46,6 +46,8 @@
                   "type": "array",
                   "items": { "type": "string" }
                 },
+                "projects_file": { "type": "string" },
+                "projid_file": { "type": "string" },
                 "hard_quota": { "type": "number" },
                 "wait_time": { "type": "integer" },
                 "min_projid": { "type": "integer" },


### PR DESCRIPTION
We should pass through the file paths from the Helm chart, so that we can configure them in YAML in our JupyterHub configurations.