### PR TITLE
feat: don't invalidate quotas

### DIFF
--- a/jupyterhub_home_nfs/generate.py
+++ b/jupyterhub_home_nfs/generate.py
@@ -429,11 +429,9 @@ class QuotaManager(Application):
         self.reconcile_quotas(is_dirty=quotas_is_dirty)
 
     def start(self):
-        # Forcibly update inodes with proper quotas
-        self.reconcile_step(quotas_is_dirty=True)
         while True:
-            time.sleep(self.wait_time)
             self.reconcile_step()
+            time.sleep(self.wait_time)
 
 
 def main():


### PR DESCRIPTION
For deployments with large home directories, the first reconciliation step can take minutes as `xfs_quota` steps through all of the files to set the proper IDs. Given that dirty tracking now reconciles the quotas on disk with the expected values _and_ the project IDs, I think we can relax this dirty-on-startup feature.