### PR TITLE
helm: add initContainers config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Enhancements made
 
 - Mkdir and chown unconditionally and let it throw errors if it fails [#56](https://github.com/2i2c-org/jupyterhub-home-nfs/pull/56) ([@GeorgianaElena](https://github.com/GeorgianaElena))
-- Setup a custom ownership uid:gid of the initial share  [#55](https://github.com/2i2c-org/jupyterhub-home-nfs/pull/55) ([@GeorgianaElena](https://github.com/GeorgianaElena), [@yuvipanda](https://github.com/yuvipanda))
+- Setup a custom ownership uid:gid of the initial share [#55](https://github.com/2i2c-org/jupyterhub-home-nfs/pull/55) ([@GeorgianaElena](https://github.com/GeorgianaElena), [@yuvipanda](https://github.com/yuvipanda))
 
 ### Contributors to this release
 

--- a/helm/jupyterhub-home-nfs/templates/deployment.yaml
+++ b/helm/jupyterhub-home-nfs/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- tpl (. | toYaml) $ | nindent 8 }}
+      {{- end }}
       containers:
       - name: nfs-server
         image: "{{ .Values.nfsServer.image.repository }}:{{ .Values.nfsServer.image.tag }}"

--- a/helm/jupyterhub-home-nfs/values.schema.json
+++ b/helm/jupyterhub-home-nfs/values.schema.json
@@ -109,6 +109,10 @@
       "required": ["type"]
     },
     "annotations": { "type": "object" },
+    "initContainers": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
     "nodeSelector": { "type": "object" },
     "affinity": { "type": "object" },
     "tolerations": {

--- a/helm/jupyterhub-home-nfs/values.yaml
+++ b/helm/jupyterhub-home-nfs/values.yaml
@@ -117,6 +117,11 @@ service:
 # Annotations for the deployment
 annotations: {}
 
+# Init containers for the deployment.
+# `tpl` is applied when rendering these, so you can include {{ .Release.Name }}
+# or references to the jupyterhub-home-nfs chart's configured values.
+initContainers: []
+
 # Node selector for the deployment
 nodeSelector: {}
 


### PR DESCRIPTION
This configuration allows me to chown `/export` on nfs-server startup. This is a workaround for #58.