### PR TITLE
feat: support defining additional containers

### DIFF
--- a/helm/jupyterhub-home-nfs/templates/deployment.yaml
+++ b/helm/jupyterhub-home-nfs/templates/deployment.yaml
@@ -107,6 +107,9 @@ spec:
           readOnly: true
         resources: {{ toJson .Values.prometheusExporter.resources }}
       {{- end }}
+      {{- with .Values.extraContainers }}
+      {{- tpl (. | toYaml) $ | nindent 6 }}
+      {{- end }}
       volumes:
       - name: home-directories
         persistentVolumeClaim:

--- a/helm/jupyterhub-home-nfs/values.schema.yaml
+++ b/helm/jupyterhub-home-nfs/values.schema.yaml
@@ -132,6 +132,10 @@ properties:
       - type
   annotations:
     type: object
+  extraContainers:
+    type: array
+    description: |
+      Additional containers for the Pod. Use a k8s native syntax.
   nodeSelector:
     type: object
   affinity:

--- a/helm/jupyterhub-home-nfs/values.yaml
+++ b/helm/jupyterhub-home-nfs/values.yaml
@@ -114,6 +114,11 @@ persistentVolume:
 service:
   type: ClusterIP
 
+# Additional containers for the deployment
+# `tpl` is applied when rendering these, so you can include {{ .Release.Name }}
+# or references to the jupyterhub-home-nfs chart's configured values.
+extraContainers: []
+
 # Annotations for the deployment
 annotations: {}
 


### PR DESCRIPTION
This PR is very similar to #59, which should likely be updated to follow. The intention is to make it easier to add containers to the NFS pod, to facilitate things like loading an SSH service.

I'm self-merging as it's a small feature addition.