### PR TITLE
Add prometheus metrics for dirsize and limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ As a prerequisite, we need to create a volume in the cloud provider to store the
 Here's an example of a values.yaml file that can be used to install the Helm chart:
 
 ```yaml
-prometheusExporter:
-  enabled: true
 gke:
   enabled: true
   volumeId: projects/example-project/zones/europe-west2-b/disks/hub-nfs-homedirs

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ helm upgrade --cleanup-on-fail \
 
 ## Security
 
-> [!WARNING]  
+> [!WARNING]
 > By default, the NFS server is accessible from within the cluster without any authentication. It is recommended to restrict access to the NFS server by enforcing Network Policies or enabling a client allow list to grant access only through kubelet and not from the pods directly.
 
 ### Network Policy Enforcement
@@ -172,7 +172,7 @@ Once the container is running, we can run the following command to get a shell i
 docker compose exec -it app bash
 ```
 
-Once we have a shell into the container, we can run `/usr/local/bin/generate.py` with the appropriate arguments to enforce storage quotas on the XFS filesystem.
+Once we have a shell into the container, we can run `python -m jupyterhub_home_nfs.generate` with the appropriate arguments to enforce storage quotas on the XFS filesystem.
 
 ### Running the tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       target: dev # Specify the development stage
     privileged: true # Needed for mounting XFS
     volumes:
-      - ./jupyterhub_home_nfs:/app
+      - ./:/app
 
   test:
     profiles: ["test"] # This service will only run when explicitly requested
@@ -16,8 +16,7 @@ services:
       target: dev # Specify the development stage
     privileged: true
     volumes:
-      - ./jupyterhub_home_nfs:/app
-      - ./tests:/app/tests
+      - .:/app
     command:
       [
         "/bin/bash",

--- a/helm/jupyterhub-home-nfs/templates/deployment.yaml
+++ b/helm/jupyterhub-home-nfs/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         securityContext:
           privileged: true
         ports:
-        - name: home-nfs-metrics
+        - name: metrics
           containerPort: 7500
         volumeMounts:
         - name: home-directories

--- a/helm/jupyterhub-home-nfs/templates/deployment.yaml
+++ b/helm/jupyterhub-home-nfs/templates/deployment.yaml
@@ -26,10 +26,6 @@ spec:
         # https://github.com/jupyterhub/grafana-dashboards/blob/18ba92d98cd297951673850a4c92507479ec4ca2/dashboards/jupyterhub.jsonnet#L322
         component: shared-volume-metrics
       annotations:
-        {{- if .Values.prometheusExporter.enabled }}
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9100"
-        {{- end }}
         # checksum of the config file to trigger a deployment when the config changes
         checksum/ganesha-config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/mounted-secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
@@ -62,6 +58,9 @@ spec:
         args: ["python", "-m", "jupyterhub_home_nfs.generate", "--config-file", "/etc/jupyterhub-home-nfs/mounted-secret/quota-enforcer-config.py"]
         securityContext:
           privileged: true
+        ports:
+        - name: home-nfs-metrics
+          containerPort: 7500
         volumeMounts:
         - name: home-directories
           mountPath: /export
@@ -88,9 +87,8 @@ spec:
           mountPath: /export
         resources: {{ toJson .Values.autoResizer.resources }}
       {{- end }}
-      {{- if .Values.prometheusExporter.enabled }}
-      - name: metrics-exporter
-        image: "{{ .Values.prometheusExporter.image.repository }}:{{ .Values.prometheusExporter.image.tag }}"
+      - name: node-exporter
+        image: "{{ .Values.nodeExporter.image.repository }}:{{ .Values.nodeExporter.image.tag }}"
         args:
         # Disable default collectors; we only want filesystem metrics
         - --collector.disable-defaults
@@ -98,15 +96,14 @@ spec:
         # Exclude some patterns of mount points to avoid collecting unnecessary metrics
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|etc|var/run/.+|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
         ports:
-        - name: metrics
+        - name: node-exporter
           containerPort: 9100
         volumeMounts:
         - name: home-directories
           # Mounting under /shared-volume to match path in dashboard definition in jupyterhub/grafana-dashboards
           mountPath: /shared-volume
           readOnly: true
-        resources: {{ toJson .Values.prometheusExporter.resources }}
-      {{- end }}
+        resources: {{ toJson .Values.nodeExporter.resources }}
       {{- with .Values.extraContainers }}
       {{- tpl (. | toYaml) $ | nindent 6 }}
       {{- end }}

--- a/helm/jupyterhub-home-nfs/templates/persistent-volume-claim.yaml
+++ b/helm/jupyterhub-home-nfs/templates/persistent-volume-claim.yaml
@@ -12,7 +12,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistentVolume.size }}
-  storageClassName: {{ .Values.persistentVolume.storageClass }}
+  {{/* Quoting is important as empty string is treated differently than null here */}}
+  storageClassName: {{ .Values.persistentVolume.storageClass | quote }}
   {{- if or .Values.eks.enabled .Values.gke.enabled .Values.openstack.enabled}}
   volumeName: {{ .Release.Name }}-{{ include "jupyterhub-home-nfs.home-nfs.fullname" . }}
   {{- end }}

--- a/helm/jupyterhub-home-nfs/templates/persistent-volume-claim.yaml
+++ b/helm/jupyterhub-home-nfs/templates/persistent-volume-claim.yaml
@@ -12,7 +12,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistentVolume.size }}
-  storageClassName: ""
+  storageClassName: {{ .Values.persistentVolume.storageClass }}
   {{- if or .Values.eks.enabled .Values.gke.enabled .Values.openstack.enabled}}
   volumeName: {{ .Release.Name }}-{{ include "jupyterhub-home-nfs.home-nfs.fullname" . }}
   {{- end }}

--- a/helm/jupyterhub-home-nfs/templates/service.yaml
+++ b/helm/jupyterhub-home-nfs/templates/service.yaml
@@ -20,7 +20,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "jupyterhub-home-nfs.home-nfs.fullname.dash" . }}node-exporter-metrics
+  name: {{ include "jupyterhub-home-nfs.fullname.dash" . }}node-exporter-metrics
   labels:
     {{- include "jupyterhub-home-nfs.labels" . | nindent 4 }}
     app.kubernetes.io/component: node-exporter-metrics
@@ -39,7 +39,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "jupyterhub-home-nfs.home-nfs.fullname.dash" . }}home-nfs-metrics
+  name: {{ include "jupyterhub-home-nfs.fullname.dash" . }}home-nfs-metrics
   labels:
     {{- include "jupyterhub-home-nfs.labels" . | nindent 4 }}
     app.kubernetes.io/component: node-exporter-metrics

--- a/helm/jupyterhub-home-nfs/templates/service.yaml
+++ b/helm/jupyterhub-home-nfs/templates/service.yaml
@@ -16,3 +16,41 @@ spec:
       port: 111
   selector:
     app: nfs-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jupyterhub-home-nfs.home-nfs.fullname.dash" . }}node-exporter-metrics
+  labels:
+    {{- include "jupyterhub-home-nfs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: node-exporter-metrics
+  annotations:
+    # Scrape the node exporter, running on port 9100
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9100"
+spec:
+  type: ClusterIP
+  ports:
+    - name: node-exporter-http
+      port: 9100
+  selector:
+    app: nfs-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jupyterhub-home-nfs.home-nfs.fullname.dash" . }}home-nfs-metrics
+  labels:
+    {{- include "jupyterhub-home-nfs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: node-exporter-metrics
+  annotations:
+    # Scrape metrics from jupyterhub_home_nfs on port 7500
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "7500"
+spec:
+  type: ClusterIP
+  ports:
+    - name: jupyterhub-home-nfs-metrics
+      port: 7500
+  selector:
+    app: nfs-server

--- a/helm/jupyterhub-home-nfs/values.schema.yaml
+++ b/helm/jupyterhub-home-nfs/values.schema.yaml
@@ -87,7 +87,7 @@ properties:
       - image
       - config
       - enabled
-  prometheusExporter:
+  nodeExporter:
     type: object
     properties:
       enabled:
@@ -177,6 +177,6 @@ properties:
 required:
   - nfsServer
   - quotaEnforcer
-  - prometheusExporter
+  - nodeExporter
   - persistentVolume
   - service

--- a/helm/jupyterhub-home-nfs/values.yaml
+++ b/helm/jupyterhub-home-nfs/values.yaml
@@ -81,11 +81,10 @@ quotaEnforcer:
 
   resources: {}
 
-# Prometheus exporter configuration
-# We export disk usage metrics using the Prometheus node exporter
-
-prometheusExporter:
-  enabled: true
+# Prometheus node exporter configuration
+# We expose disk total usage + some other disk metrics with prometheus
+# node exporter
+nodeExporter:
   image:
     repository: quay.io/prometheus/node-exporter
     tag: v1.8.2

--- a/jupyterhub_home_nfs/metrics.py
+++ b/jupyterhub_home_nfs/metrics.py
@@ -3,11 +3,15 @@ from prometheus_client import Gauge
 NAMESPACE = "dirsize"
 
 TOTAL_SIZE = Gauge(
-    "total_size_bytes", "Total Size of the Directory (in bytes)", namespace=NAMESPACE,
-    labelnames=("directory",)
+    "total_size_bytes",
+    "Total Size of the Directory (in bytes)",
+    namespace=NAMESPACE,
+    labelnames=("directory",),
 )
 
 HARD_LIMIT = Gauge(
-    "hard_limit_bytes", "Hard Limit of the Directory (in bytes)", namespace=NAMESPACE,
-    labelnames=("directory",)
+    "hard_limit_bytes",
+    "Hard Limit of the Directory (in bytes)",
+    namespace=NAMESPACE,
+    labelnames=("directory",),
 )

--- a/jupyterhub_home_nfs/metrics.py
+++ b/jupyterhub_home_nfs/metrics.py
@@ -1,0 +1,13 @@
+from prometheus_client import Gauge
+
+NAMESPACE = "dirsize"
+
+TOTAL_SIZE = Gauge(
+    "total_size_bytes", "Total Size of the Directory (in bytes)", namespace=NAMESPACE,
+    labelnames=("directory",)
+)
+
+HARD_LIMIT = Gauge(
+    "hard_limit_bytes", "Hard Limit of the Directory (in bytes)", namespace=NAMESPACE,
+    labelnames=("directory",)
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 dependencies = [
     "traitlets>=5.13.0",
     "ruamel-yaml==0.18.10",
+    "prometheus-client"
 ]
 
 [project.urls]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -449,7 +449,9 @@ def test_metrics(quota_manager):
             name="dirsize_hard_limit_bytes",
             labels={"directory": "user"},
             # The value is in bytes, not gb (used by jupyterhub-home-nfs) or kb (used by xfs)
-            value=pytest.approx(0.004 * 1024 * 1024 * 1024, abs=DEFAULT_BLOCK_SIZE_KIB * 1024),
+            value=pytest.approx(
+                0.004 * 1024 * 1024 * 1024, abs=DEFAULT_BLOCK_SIZE_KIB * 1024
+            ),
         )
         in collected_hardlimit_metric.samples
     )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -156,9 +156,9 @@ def test_exclude_dirs(quota_manager):
 
     applied_quotas = quota_manager.get_applied_quotas()
     assert applied_quotas[os.path.join(MOUNT_POINT, "a")] == {
-        "blocks": {"soft": 0, "hard": 1000},
-        "inodes": {"soft": 0, "hard": 0},
-        "realtime": {"soft": 0, "hard": 0},
+        "blocks": {"soft": 0, "hard": 1000, "used": 0},
+        "inodes": {"soft": 0, "hard": 0, "used": 1},
+        "realtime": {"soft": 0, "hard": 0, "used": 0},
     }
 
     # Now reconcile with exclusions
@@ -167,9 +167,9 @@ def test_exclude_dirs(quota_manager):
 
     applied_quotas = quota_manager.get_applied_quotas()
     assert applied_quotas[os.path.join(MOUNT_POINT, "a")] == {
-        "blocks": {"soft": 0, "hard": 0},
-        "inodes": {"soft": 0, "hard": 0},
-        "realtime": {"soft": 0, "hard": 0},
+        "blocks": {"soft": 0, "hard": 0, "used": 0},
+        "inodes": {"soft": 0, "hard": 0, "used": 1},
+        "realtime": {"soft": 0, "hard": 0, "used": 0},
     }
 
     # Create a 2MB test file using a temporary file
@@ -296,8 +296,8 @@ def test_quota_overrides(quota_manager):
     quota_manager.reconcile_step()
 
     invariant_quota = {
-        "inodes": {"soft": 0, "hard": 0},
-        "realtime": {"soft": 0, "hard": 0},
+        "inodes": {"soft": 0, "hard": 0, "used": 1},
+        "realtime": {"soft": 0, "hard": 0, "used": 0},
     }
 
     applied_quotas = quota_manager.get_applied_quotas()
@@ -310,6 +310,7 @@ def test_quota_overrides(quota_manager):
     # 1. "regular": should get default hard_quota (0.001 GiB)
     assert applied_quotas[os.path.join(MOUNT_POINT, "regular")] == {
         "blocks": {
+            "used": 0,
             "soft": 0,
             "hard":
             # Tolerance of 4k default block size
@@ -322,6 +323,7 @@ def test_quota_overrides(quota_manager):
         "blocks": {
             "soft": 0,
             "hard": 0,
+            "used": 0
         },
         **invariant_quota,
     }
@@ -329,6 +331,7 @@ def test_quota_overrides(quota_manager):
     # 3. "override": should get custom quota (0.005 GiB)
     assert applied_quotas[os.path.join(MOUNT_POINT, "override")] == {
         "blocks": {
+            "used": 0,
             "soft": 0,
             "hard":
             # Tolerance of 4k default block size
@@ -341,6 +344,7 @@ def test_quota_overrides(quota_manager):
     # This tests that quota_overrides takes priority over exclude
     assert applied_quotas[os.path.join(MOUNT_POINT, "both")] == {
         "blocks": {
+            "used": 0,
             "soft": 0,
             "hard":
             # Tolerance of 4k default block size
@@ -441,13 +445,14 @@ def test_quota_overrides_cli(tmp_path):
     applied_quotas = quota_manager.get_applied_quotas()
     assert applied_quotas[os.path.join(MOUNT_POINT, "test")] == {
         "blocks": {
+            "used": 0,
             "soft": 0,
             "hard":
             # Tolerance of 4k default block size
             pytest.approx(0.002 * GIB_TO_KIB, abs=DEFAULT_BLOCK_SIZE_KIB),
         },
-        "inodes": {"soft": 0, "hard": 0},
-        "realtime": {"soft": 0, "hard": 0},
+        "inodes": {"soft": 0, "hard": 0, "used": 1},
+        "realtime": {"soft": 0, "hard": 0, "used": 0},
     }, "Expected quota of 0.002 GiB for 'test'"
 
 
@@ -470,16 +475,19 @@ def test_quota_clear(quota_manager):
         path = os.path.join(MOUNT_POINT, name)
         assert applied_quotas[path] == {
             "blocks": {
+                "used": 0,
                 "soft": 0,
                 "hard": 1048576,
             },
             "inodes": {
                 "soft": 0,
                 "hard": 0,
+                "used": 1
             },
             "realtime": {
                 "soft": 0,
                 "hard": 0,
+                "used": 0
             },
         }
 
@@ -502,14 +510,17 @@ def test_quota_clear(quota_manager):
     path = os.path.join(MOUNT_POINT, "beta")
     assert applied_quotas[path] == {
         "blocks": {
+            "used": 0,
             "soft": 0,
             "hard": 1048576,
         },
         "inodes": {
+            "used": 1,
             "soft": 0,
             "hard": 10,
         },
         "realtime": {
+            "used": 0,
             "soft": 0,
             "hard": 0,
         },
@@ -521,14 +532,17 @@ def test_quota_clear(quota_manager):
         path = os.path.join(MOUNT_POINT, name)
         assert applied_quotas[path] == {
             "blocks": {
+                "used": 0,
                 "soft": 0,
                 "hard": 1048576,
             },
             "inodes": {
+                "used": 1,
                 "soft": 0,
                 "hard": 0,
             },
             "realtime": {
+                "used": 0,
                 "soft": 0,
                 "hard": 0,
             },
@@ -543,14 +557,17 @@ def test_quota_clear(quota_manager):
         path = os.path.join(MOUNT_POINT, name)
         assert applied_quotas[path] == {
             "blocks": {
+                "used": 0,
                 "soft": 0,
                 "hard": 1048576,
             },
             "inodes": {
+                "used": 1,
                 "soft": 0,
                 "hard": 0,
             },
             "realtime": {
+                "used": 0,
                 "soft": 0,
                 "hard": 0,
             },


### PR DESCRIPTION
While working on https://github.com/2i2c-org/infrastructure/issues/7166, I realized
that for alerts on a per-user level to be useful, it's critical that we have information about
per-user limits. Currently limits are overriden per-user, and in the future we may have
groups too.

While [my initial suggestion](https://github.com/2i2c-org/infrastructure/issues/7029)
to improve the experience was to run dirsize-exporter in the same pod (so mounted with xfs not NFS), 
that won't give us per-user limits. We should still do that, since dirsize-exporter offers
additional info (about total number of files + the oldest file in a dir, both helpful information)
that isn't present in the xfs info.

This PR adds:

- Infrastructure for prometheus metrics in the reconciler script
- Two metrics - `total_size_bytes` (total used size) and `hard_limit_bytes` (hard limit) per 
   directory.
- Default namespace for the metric names is `dirsize`, so that existing graphs in grafana
   will work regardless of the *source* of the metrics. This is important since not everyone
   using jupyterhub will be using jupyterhub-home-nfs
- Switch to using a Kubernetes service to tell prometheus what to scrape, rather than
   using pod annotations. This allows us to scrape multiple ports on the same pod, so
   we can continue using node-exporter for disk metrics while getting usage metrics
   out of jupyterhub-home-nfs, and in the future getting other metrics out of dirsize
   exporter
- Fix bug causing storageClassName to not be set on PVC. Was necessary for local
   testing.

An alternative I considered is to add support for XFS quotas in prometheus-dirsize-exporter.
However, since home-nfs puts projid and projects files not in their standard locations,
that would be a little more complex. Plus we may not have info about what dirs to report
on and what to not (we only want to report on the paths we manage). So I kept it in here.
Happy to reconsider too.

We should add an option to https://github.com/2i2c-org/prometheus-dirsize-exporter to
allow disabling the dirsize total size bytes so we don't have duplicate metrics.

Validated that this works and prometheus does pick up the metrics:

<img width="1904" height="887" alt="image" src="https://github.com/user-attachments/assets/2e7fab09-2f22-4705-9cd4-0d82fe27f5eb" />


## TODO

- [x] Expose the metrics via the helm chart
- [ ] Document the metrics in the README