### PR TITLE
Allow disabling nodeExporter

### DIFF
--- a/helm/jupyterhub-home-nfs/templates/deployment.yaml
+++ b/helm/jupyterhub-home-nfs/templates/deployment.yaml
@@ -87,6 +87,7 @@ spec:
           mountPath: /export
         resources: {{ toJson .Values.autoResizer.resources }}
       {{- end }}
+      {{ if .Values.nodeExporter.enabled }}
       - name: node-exporter
         image: "{{ .Values.nodeExporter.image.repository }}:{{ .Values.nodeExporter.image.tag }}"
         args:
@@ -104,6 +105,7 @@ spec:
           mountPath: /shared-volume
           readOnly: true
         resources: {{ toJson .Values.nodeExporter.resources }}
+      {{- end }}
       {{- with .Values.extraContainers }}
       {{- tpl (. | toYaml) $ | nindent 6 }}
       {{- end }}

--- a/helm/jupyterhub-home-nfs/templates/service.yaml
+++ b/helm/jupyterhub-home-nfs/templates/service.yaml
@@ -17,6 +17,7 @@ spec:
   selector:
     app: nfs-server
 ---
+{{ if .Values.nodeExporter.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -36,6 +37,7 @@ spec:
   selector:
     app: nfs-server
 ---
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/jupyterhub-home-nfs/values.yaml
+++ b/helm/jupyterhub-home-nfs/values.yaml
@@ -85,6 +85,7 @@ quotaEnforcer:
 # We expose disk total usage + some other disk metrics with prometheus
 # node exporter
 nodeExporter:
+  enabled: true
   image:
     repository: quay.io/prometheus/node-exporter
     tag: v1.8.2


### PR DESCRIPTION
This used to be called 'prometheusExporter'

Follow-up to https://github.com/2i2c-org/jupyterhub-home-nfs/pull/76

Note that this renames what used to be `prometheusExporter`