### PR TITLE
Reduce restart disruption by shortening lease and grace periods (60->20 and 90->30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ initContainers:
       runAsUser: 0
 ```
 
+## Operation
+
+### Server restarts
+
+When restarting the NFS server, it will be in a recovery mode ("in grace") for
+30 seconds where only recovery related operations are allowed. Due to this,
+normal usage is disrupted for about 40 seconds or so if you restart the
+nfs-server pod.
+
 ## Development
 
 ### Prerequisites

--- a/helm/jupyterhub-home-nfs/templates/configmap.yaml
+++ b/helm/jupyterhub-home-nfs/templates/configmap.yaml
@@ -37,3 +37,17 @@ data:
             Name = VFS;
         }
     }
+
+    NFSv4 {
+        # During the startup grace period, the NFS server only accepts recovery
+        # related operations, and will block normal operations. It is a
+        # mechanism to avoid corruption issues by allowing clients to finalize
+        # things they had a lease for before they lost connectivity, allowing
+        # other clients to start doing new things.
+        #
+        # Lease_Lifetime defaults to 60, and Grace_Period to 90. We retain the
+        # 1.5 ratio as their relative proportions was of importance.
+        #
+        Lease_Lifetime = 20;
+        Grace_Period = 30;
+    }


### PR DESCRIPTION
- resolves #78

With this change, nfs server pod restarts are 1 minute less disruptive, but it may lead to a bit more lease acquisition operations. This reduced time made me not observe popups during a restart from vscode as a UI, while I did before.