### PR TITLE
adding some convenience tools to the nfs server image

### DIFF
--- a/helm/jupyterhub-home-nfs/templates/configmap.yaml
+++ b/helm/jupyterhub-home-nfs/templates/configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "jupyterhub-home-nfs.home-nfs.fullname" . }}-ganesha-config
 data:
   ganesha.conf: |
+    {{ .Values.nfsServer.extraGaneshaConfig | nindent 4 }}
     EXPORT
     {
         # Export Id (mandatory, each EXPORT must have a unique Export_Id)

--- a/helm/jupyterhub-home-nfs/values.schema.yaml
+++ b/helm/jupyterhub-home-nfs/values.schema.yaml
@@ -16,6 +16,8 @@ properties:
           - tag
       resources:
         type: object
+      extraGaneshaConfig:
+        type: string
     required:
       - image
   autoResizer:

--- a/helm/jupyterhub-home-nfs/values.yaml
+++ b/helm/jupyterhub-home-nfs/values.yaml
@@ -32,6 +32,8 @@ nfsServer:
   allowedClients:
     - "127.0.0.1" # allow localhost
 
+  extraGaneshaConfig: ''
+
 # Automatic filesystem resizer, so increases in underlying disk size
 # are immediately reflected in available file system
 autoResizer:

--- a/nfs-ganesha/Dockerfile
+++ b/nfs-ganesha/Dockerfile
@@ -1,13 +1,9 @@
-FROM ubuntu:22.04
+FROM debian:forky
 
 RUN DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
-    && apt-get install -y software-properties-common \
-    && add-apt-repository ppa:nfs-ganesha/nfs-ganesha-5 \
-    && add-apt-repository ppa:nfs-ganesha/libntirpc-5 \
-    && apt-get update \
-    && apt-get install -y netbase nfs-common dbus nfs-ganesha nfs-ganesha-vfs \
-    && apt-get install -y vim screen rsync less tree \
+    && apt-get install -y \
+      netbase nfs-common dbus nfs-ganesha nfs-ganesha-vfs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && mkdir -p /run/rpcbind /export /var/run/dbus \

--- a/nfs-ganesha/Dockerfile
+++ b/nfs-ganesha/Dockerfile
@@ -2,17 +2,9 @@ FROM debian:forky
 
 RUN DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
-<<<<<<< HEAD
     && apt-get install -y \
       netbase nfs-common dbus nfs-ganesha nfs-ganesha-vfs \
-=======
-    && apt-get install -y software-properties-common \
-    && add-apt-repository ppa:nfs-ganesha/nfs-ganesha-5 \
-    && add-apt-repository ppa:nfs-ganesha/libntirpc-5 \
-    && apt-get update \
-    && apt-get install -y netbase nfs-common dbus nfs-ganesha nfs-ganesha-vfs \
-    && apt-get install -y vim screen rsync less \
->>>>>>> 3c0d18f (adding some convenience tools to the nfs server)
+    && apt-get install -y vim screen rsync less tree \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && mkdir -p /run/rpcbind /export /var/run/dbus \

--- a/nfs-ganesha/Dockerfile
+++ b/nfs-ganesha/Dockerfile
@@ -7,6 +7,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     && add-apt-repository ppa:nfs-ganesha/libntirpc-5 \
     && apt-get update \
     && apt-get install -y netbase nfs-common dbus nfs-ganesha nfs-ganesha-vfs \
+    && apt-get install -y vim screen rsync less \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && mkdir -p /run/rpcbind /export /var/run/dbus \

--- a/nfs-ganesha/Dockerfile
+++ b/nfs-ganesha/Dockerfile
@@ -2,8 +2,17 @@ FROM debian:forky
 
 RUN DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
+<<<<<<< HEAD
     && apt-get install -y \
       netbase nfs-common dbus nfs-ganesha nfs-ganesha-vfs \
+=======
+    && apt-get install -y software-properties-common \
+    && add-apt-repository ppa:nfs-ganesha/nfs-ganesha-5 \
+    && add-apt-repository ppa:nfs-ganesha/libntirpc-5 \
+    && apt-get update \
+    && apt-get install -y netbase nfs-common dbus nfs-ganesha nfs-ganesha-vfs \
+    && apt-get install -y vim screen rsync less \
+>>>>>>> 3c0d18f (adding some convenience tools to the nfs server)
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && mkdir -p /run/rpcbind /export /var/run/dbus \

--- a/nfs-ganesha/Dockerfile
+++ b/nfs-ganesha/Dockerfile
@@ -7,7 +7,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     && add-apt-repository ppa:nfs-ganesha/libntirpc-5 \
     && apt-get update \
     && apt-get install -y netbase nfs-common dbus nfs-ganesha nfs-ganesha-vfs \
-    && apt-get install -y vim screen rsync less \
+    && apt-get install -y vim screen rsync less tree \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && mkdir -p /run/rpcbind /export /var/run/dbus \


### PR DESCRIPTION
i'm in the process of (finally) getting this deployed for the cal-icor hubs, and when i started the data migration some basic tools were missing:  vim, screen, rsync and less.

i figured these are handy and small/generic enough that they should probably be installed by default.  :)