### PR TITLE
Only test the version of python we use in our Dockerfile

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,16 +12,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          # Set up the python version used in the docker image specified in `Dockerfile`
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# If we upgrade this, also update the python version we test with,
+# in .github/workflows/python-package.yml
 FROM ubuntu:24.04 AS base
 
 RUN apt-get update > /dev/null && \


### PR DESCRIPTION
We don't need to support other python versions, as the only supported way to run this is with our Dockerfile