### PR TITLE
Bump base of nfs-ganesha dockerfile

### DIFF
--- a/nfs-ganesha/Dockerfile
+++ b/nfs-ganesha/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN DEBIAN_FRONTEND=noninteractive \
     && apt-get update \


### PR DESCRIPTION
Move from Ubuntu 22.04 to 24.04, matching up with what we use for the xfs quota script. We can move together to 26.04 at some point.